### PR TITLE
使用公司的发布插件将 Athena 发布到 Maven Central

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -128,7 +128,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Release
-        uses: QubitPi/maven-central-release-action@master
+        uses: paion-data/maven-central-release@master
         with:
           user: QubitPi
           email: jack20220723@gmail.com


### PR DESCRIPTION
## Changelog

### Added

### Changed

- 公司的 Maven Central 插件已经发布，现在需要将其用到我们的 Maven 项目中，将 athena 发布出去

### Deprecated

### Removed

### Fixed

### Security

## Checklist

- [x] Test
- [x] Self-review
- [ ] Documentation
