### PR TITLE
支持在 athena-spring-boot-starter 中自动生成 Maven Central 发布需要的 javadoc 和 sources JAR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -579,6 +579,26 @@
                                 <goal>test-jar</goal>
                             </goals>
                         </execution>
+                        <execution>
+                            <id>javadoc-jar</id>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
+                            <configuration>
+                                <classifier>javadoc</classifier>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>sources-jar</id>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
+                            <configuration>
+                                <classifier>sources</classifier>
+                            </configuration>
+                        </execution>
                     </executions>
                 </plugin>
             </plugins>


### PR DESCRIPTION
## Changelog

### Added

### Changed

### Deprecated

### Removed

### Fixed

- 通过配置 maven-jar-plugin 的自动生成逻辑，修复了 [Maven Central 发包失败](https://github.com/paion-data/athena/actions/runs/8703524781/job/23869951980)的问题

### Security

## Checklist

- [x] Test

  - 本地 `mvn clean verify` 已验证：
    
    <img width="898" alt="page" src="https://github.com/paion-data/athena/assets/16126939/3850b334-9b24-4af3-af99-83e86c42a3fe">

- [x] Self-review
- [ ] Documentation
