### PR TITLE
Put test to right location

### DIFF
--- a/athena-core/src/test/groovy/com/paiondata/athena/file/identifier/FileIdGeneratorFactorySpec.groovy
+++ b/athena-core/src/test/groovy/com/paiondata/athena/file/identifier/FileIdGeneratorFactorySpec.groovy
@@ -13,9 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.paiondata.athena.file
-
-import com.paiondata.athena.file.identifier.FileIdGeneratorFactory
+package com.paiondata.athena.file.identifier
 
 import spock.lang.Specification
 


### PR DESCRIPTION
## Changelog

### Added

### Changed

### Deprecated

### Removed

### Fixed

- https://github.com/paion-data/athena/pull/46 puts the test in wrong location which is fixed in this PR

### Security

## Checklist

- [x] Test
- [x] Self-review
- [ ] Documentation
