### PR TITLE
Fix release error

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -137,3 +137,4 @@ jobs:
           gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
           server-username: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
           server-password: ${{ secrets.MAVEN_CENTRAL_TOKEN }}
+          version-properties: version.athena

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -134,9 +134,9 @@ mvn clean package
 ```
 
 Successfully executing the command above shall generate a ".war" file under
-`athena/athena-examples/athena-example-books/target/athena-example-books-<athena-version>.war`, where
-is the version of the athena, for example `1.0.2`, please make sure to replace `<athena-version>` with one of our
-release versions.
+`athena/athena-examples/athena-example-books/target/athena-example-books-<athena-version>.war`, where is the version of
+the athena, for example `1.0.2`, please make sure to replace `<athena-version>` with one of
+[our release versions](https://central.sonatype.com/namespace/com.paiondata.athena).
 
 ### Setting Up Jetty
 


### PR DESCRIPTION
## Changelog

### Added

### Changed

### Deprecated

### Removed

### Fixed

- 修复了 Maven Central 发包失败的问题，原因是[发布插件传参有更新](https://github.com/paion-data/maven-central-release-action/pull/8)，这里没有传新的参数过去

### Security

## Checklist

- [x] Test
- [x] Self-review
- [ ] Documentation
