### PR TITLE
Revert "Remove unused rest-assured dependency (#74)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -336,6 +336,18 @@
                 <version>${version.jetty}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>io.rest-assured</groupId>
+                <artifactId>rest-assured</artifactId>
+                <version>5.3.0</version>
+                <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.groovy</groupId>
+                        <artifactId>groovy</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Reverts paion-data/athena#34

为了实现 https://github.com/paion-data/athena/pull/45 ，将之前暂时停用的依赖再次启用