### PR TITLE
修复项目中 spring 封装下的接口所存在的问题

### DIFF
--- a/athena-spring/athena-spring-boot-autoconfigure/src/main/java/com/paiondata/athena/spring/boot/autoconfigure/config/WebConfig.java
+++ b/athena-spring/athena-spring-boot-autoconfigure/src/main/java/com/paiondata/athena/spring/boot/autoconfigure/config/WebConfig.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 Paion Data
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.paiondata.athena.spring.boot.autoconfigure.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void configurePathMatch(PathMatchConfigurer configurer) {
+        configurer.addPathPrefix("/v1", c -> true);
+    }
+}

--- a/athena-spring/athena-spring-boot-autoconfigure/src/main/java/com/paiondata/athena/spring/boot/autoconfigure/config/WebConfig.java
+++ b/athena-spring/athena-spring-boot-autoconfigure/src/main/java/com/paiondata/athena/spring/boot/autoconfigure/config/WebConfig.java
@@ -19,11 +19,21 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+/**
+ * Configuration for the web
+ * <p>
+ * This configuration is used to add a prefix to all the endpoints.
+ */
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
+    /**
+     * Add a prefix to all the endpoints.
+     *
+     * @param configurer the path match configurer
+     */
     @Override
-    public void configurePathMatch(PathMatchConfigurer configurer) {
+    public void configurePathMatch(final PathMatchConfigurer configurer) {
         configurer.addPathPrefix("/v1", c -> true);
     }
 }

--- a/athena-spring/athena-spring-boot-autoconfigure/src/main/java/com/paiondata/athena/spring/boot/autoconfigure/controller/MetaController.java
+++ b/athena-spring/athena-spring-boot-autoconfigure/src/main/java/com/paiondata/athena/spring/boot/autoconfigure/controller/MetaController.java
@@ -26,7 +26,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import graphql.ExecutionResult;
@@ -64,7 +66,7 @@ public class MetaController {
      * @throws NullPointerException if {@code query} is {@code null}
      */
     @GetMapping
-    public ExecutionResult get(@NotNull final String query) {
+    public ExecutionResult get(@NotNull @RequestParam("query") final String query) {
         return metaStore.executeNative(Objects.requireNonNull(query));
     }
 
@@ -86,7 +88,7 @@ public class MetaController {
      * @throws IllegalArgumentException if no metadata fields are found in {@code graphQLDocument}
      */
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
-    public ExecutionResult post(@NotNull final String graphQLDocument) {
+    public ExecutionResult post(@NotNull @RequestBody final String graphQLDocument) {
         Objects.requireNonNull(graphQLDocument);
 
         final List<String> requestedMetadataFields = jsonDocumentParser.getFields(graphQLDocument);

--- a/athena-spring/athena-spring-boot-autoconfigure/src/test/groovy/com/paiondata/athena/spring/boot/autoconfigure/controller/FileControllerITSpec.groovy
+++ b/athena-spring/athena-spring-boot-autoconfigure/src/test/groovy/com/paiondata/athena/spring/boot/autoconfigure/controller/FileControllerITSpec.groovy
@@ -45,7 +45,7 @@ class FileControllerITSpec extends AbstractITSpec {
 
         MockHttpServletRequestBuilder builder =
                 MockMvcRequestBuilders
-                        .multipart("/file/upload")
+                        .multipart("/v1/file/upload")
                         .file(mockMultipartFile)
 
         then:


### PR DESCRIPTION
## Changelog

### Added

### Changed

### Deprecated

### Removed

### Fixed
之前在 athena-spring-boot-autoconfigure 模块下编写的接口访问时存在 bug，现在进行修复，并统一加上 v1 的路径访问前缀

### Security

## Checklist

- [ ] Test
- [ ] Self-review
- [ ] Documentation
